### PR TITLE
fix: link to the article explaining homomorphic hiding

### DIFF
--- a/MODULE_4.md
+++ b/MODULE_4.md
@@ -15,7 +15,7 @@ This blog series from Electric Coin is a good start:
 
 ASecuritySite.com also has some helpful interactive examples that go along with these two blog posts:
 
-- [zkSNARK (Homomorphic Hiding)](https://asecuritysite.com/zero/zksnark02)
+- [zkSNARK (Homomorphic Hiding)](https://asecuritysite.com/zero/zksnark01)
 - [zkSNARK (Blind Evaluation Problem)](https://asecuritysite.com/zero/zksnark02)
 
 ## 2. From Computation to QAP


### PR DESCRIPTION
### Description

The link to the article explaining homomorphic hiding is incorrect.

### Related Issues

#1

### Affected Tutorials

- Module Name: MODULE_4.md
- Section/Step: Homomorphic Hiding and Blind Evaluation

### Type of Change

- [x] Typo/grammar fix
- [ ] Code correction (e.g., a bug in a code snippet)
- [ ] New tutorial or section
- [ ] Other (please describe):

### Testing

I have verified that the link destination is correct.

### Checklist

- [x] I have performed a self-review of my own changes.
- [x] I have made corresponding changes to related documentation.
